### PR TITLE
feat: add version 0.4.6.10

### DIFF
--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "0.4.6-rc10",
+    "stable": true,
+    "files": [
+      {
+        "filename": "tor-darwin-amd64-0.4.6.10.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/tor-actions/versions/releases/download/0.4.6.10/tor-darwin-amd64-0.4.6.10.tar.gz"
+      },
+      {
+        "filename": "tor-linux-amd64-0.4.6.10.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/tor-actions/versions/releases/download/0.4.6.10/tor-linux-amd64-0.4.6.10.tar.gz"
+      },
+      {
+        "filename": "tor-win32-0.4.6.10.tar.gz",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/tor-actions/versions/releases/download/0.4.6.10/tor-win32-0.4.6.10.tar.gz"
+      }
+    ]
+  },
+  {
     "version": "0.4.5-rc11",
     "stable": true,
     "files": [


### PR DESCRIPTION
I guess if https://github.com/tor-actions/versions/pull/4 gets merged, it will automatically re-create this PR. 👍🏻