### PR TITLE
ci: add workflow to update build scripts

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           repository: tor-actions/tor-build-scripts
           ref: master
-          token: ${{ secrets.TOR_BUILD_SCRIPTS_TOKEN }}
 
       - name: Get SHA256 checksum
         id: checksum
@@ -68,7 +67,7 @@ jobs:
         id: create_pull_request
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.TOR_BUILD_SCRIPTS_TOKEN }}
+          token: ${{ secrets.TOC_ACTION_ACCESS_REPO }}
           commit-message: "release: add version v${{ needs.check.outputs.latest_version }}"
           committer: GitHub Action <noreply@github.com>
           title: "release: add version v${{ needs.check.outputs.latest_version }}"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -35,10 +35,53 @@ jobs:
           echo "The latest version of Tor on the website is:  ${{ steps.latest_version.outputs.latest_version_formatted }} (${{ steps.latest_version.outputs.latest_version }})"
           echo "The latest version of Tor in the manifest is: ${{ steps.manifest_version.outputs.manifest_version }}"
 
+  update-build-scripts:
+    name: Update Build Scripts
+    runs-on: ubuntu-latest
+    needs: ['check']
+    outputs:
+      pull_request_url: ${{ steps.create_pull_request.outputs.pull-request-url }}
+    if: ${{ needs.check.outputs.latest_version_formatted != needs.check.outputs.manifest_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: tor-actions/tor-build-scripts
+          ref: master
+          token: ${{ secrets.TOR_BUILD_SCRIPTS_TOKEN }}
+
+      - name: Get SHA256 checksum
+        id: checksum
+        run: |
+          checksum=$(curl https://dist.torproject.org/tor-${{ needs.check.outputs.latest_version }}.tar.gz.sha256sum)
+          checksum=$(echo "${checksum}" | grep -oE "[a-f0-9]{64}")
+          echo "::set-output name=checksum::${checksum}"
+
+      - name: Update `env.sh` file
+        run: |
+          env_file_contents="$(cat env.sh)"
+          env_file_contents="$(echo "${env_file_contents}" | sed -e 's#export TOR_VERSION="[0-9]*\.[0-9]*\.[0-9]*\.[0-9]"#export TOR_VERSION=\"${{ needs.check.outputs.latest_version }}\"#g')"
+          env_file_contents="$(echo "${env_file_contents}" | sed -E 's#export TOR_HASH=[a-f0-9]{64}#export TOR_HASH={{ steps.checksum.outputs.checksum }}#g')"
+          echo "${env_file_contents}" > env.sh
+
+      - name: Create PR for latest version
+        id: create_pull_request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.TOR_BUILD_SCRIPTS_TOKEN }}
+          commit-message: "release: add version v${{ needs.check.outputs.latest_version }}"
+          committer: GitHub Action <noreply@github.com>
+          title: "release: add version v${{ needs.check.outputs.latest_version }}"
+          body: |
+            This updates from ${{ needs.check.outputs.manifest_version }} to ${{ needs.check.outputs.latest_version }}.
+            - [Changelog](https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-${{ needs.check.outputs.latest_version }})
+            - [Tag](https://gitweb.torproject.org/tor.git/tag/?h=tor-${{ needs.check.outputs.latest_version }})
+          branch: release/newver-${{ needs.check.outputs.latest_version }}
+
   update:
     name: Update
     runs-on: ubuntu-latest
-    needs: ['check']
+    needs: ['check', 'update-build-scripts']
     if: ${{ needs.check.outputs.latest_version_formatted != needs.check.outputs.manifest_version }}
     steps:
       - name: Checkout
@@ -57,12 +100,14 @@ jobs:
           rm versions-manifest.json.bak
 
       - name: Create PR for latest version
+        id: create_pull_request
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: "release: add version v${{ needs.check.outputs.latest_version }}"
           committer: GitHub Action <noreply@github.com>
           title: "release: add version v${{ needs.check.outputs.latest_version }} (${{ needs.check.outputs.latest_version_formatted }})"
           body: |
+            This should be merged after: ${{ needs.update-build-scripts.outputs.pull_request_url }}
             This updates from ${{ needs.check.outputs.manifest_version }} to ${{ needs.check.outputs.latest_version_formatted }}.
             - [Changelog](https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-${{ needs.check.outputs.latest_version }})
             - [Tag](https://gitweb.torproject.org/tor.git/tag/?h=tor-${{ needs.check.outputs.latest_version }})


### PR DESCRIPTION
This should (not fully tested) add support for updating the `tor-build-scripts` repository with a PR when a new version releases (as per your comment https://github.com/tor-actions/versions/pull/11#issuecomment-1046853783). 👍🏻

It will require a `TOR_BUILD_SCRIPTS_TOKEN` secret in order to work as it needs to open a PR on another repository. 👍🏻