### PR TITLE
change default branch name

### DIFF
--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_MIRROR }}
         run: |
+          git config --global init.defaultBranch main
           git clone --bare https://git.torproject.org/builders/tor-browser-build.git .
           git remote add github "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${{ github.repository_owner }}/tor-browser-build.git"
           git push --mirror github


### PR DESCRIPTION
Not sure if this is the exact commit, but it references the change from master to main: https://gitweb.torproject.org/builders/tor-browser-build.git/commit/?h=main&id=2a6dd31208e5a1b4ebc0bebc0e48e702c84da03e

This should fix the recent errors with the mirrors action failing.